### PR TITLE
Fix customization of helm templates

### DIFF
--- a/helm/templates/boavizta-deployment.yaml
+++ b/helm/templates/boavizta-deployment.yaml
@@ -17,8 +17,8 @@ spec:
     spec:
       containers:
       - name: boaviztapi-container
-        image: ghcr.io/boavizta/boaviztapi:latest   # Docker image to run
-        ports:
+        image: "{{ .Values.boavizta.image.repository }}:{{ .Values.boavizta.image.tag }}" # Docker image to run
+        ports: 
         - containerPort: 5000  # Exposing port 5000 on the container
         # Define resource requests and limits if needed
         resources:
@@ -43,4 +43,3 @@ spec:
       targetPort: 5000  # The port on the container that the traffic will be directed to
   selector:
     app: boaviztapi
-

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -15,8 +15,14 @@ spec:
     spec:
       containers:
       - name: keit-app-container
-        image: ghcr.io/aknostic/keit:0.0.3
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 8080
-
+        resources:
+          requests:
+            cpu: 50m
+            memory: 50Mi
+          limits:
+            cpu: 50m
+            memory: 50Mi

--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.servicemonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -18,3 +19,4 @@ spec:
       path: /metrics
       interval: {{ .Values.servicemonitor.interval }}
       scrapeTimeout: {{ .Values.servicemonitor.scrapeTimeout }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -12,14 +12,13 @@ service:
 namespace: keit
 
 boavizta:
-  enabled: true
   image:
-    repository: boavizta/boavizta-app
+    repository: ghcr.io/boavizta/boaviztapi
     tag: latest
     pullPolicy: Always
   replicaCount: 1
 
 servicemonitor:
   enabled: true
-  interval: 15m
-  scrapeTimeout: 2m
+  interval: 1m
+  scrapeTimeout: 1m

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -20,5 +20,5 @@ boavizta:
 
 servicemonitor:
   enabled: true
-  interval: 1m
-  scrapeTimeout: 1m
+  interval: 15m
+  scrapeTimeout: 2m


### PR DESCRIPTION
The file values.yaml contained many values that were not used by the helm templates. This PR fixes that.

It also adds resource requests and limits to the container of the keit exporter.