### PR TITLE
removing unused values for namespace

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -20,9 +20,6 @@ service:
   # port specifies the port number on which Keit service will be exposed internally
   port: 8080
 
-# namespace specifies the Kubernetes namespace where Keit resources will be deployed
-namespace: keit
-
 # boavizta contains configuration for the Boavizta deployment
 boavizta:
   # image contains container image details for Boavizta


### PR DESCRIPTION
The namespace value is not used by any template:
```
frey@Deepness:~/GH_Repos/keit/helm $ grep "namespace:" templates/*
templates/boavizta-deployment.yaml:  namespace: {{ .Release.Namespace }} 
templates/boavizta-deployment.yaml:  namespace: {{ .Release.Namespace }}
templates/clusterrolebinding-node-reader.yaml:  namespace: {{ .Release.Namespace }}
templates/clusterrolebinding.yaml:  namespace: {{ .Release.Namespace }} 
templates/deployment.yaml:  namespace: {{ .Release.Namespace }}
templates/servicemonitor.yaml:  namespace: {{ .Release.Namespace }}
templates/service.yaml:  namespace: {{ .Release.Namespace }}
```

namespace is defined during Helm chart deployment via the "--namespace" flag